### PR TITLE
Fix Proxy and other contracts working with it

### DIFF
--- a/contracts/proxies/GnosisSafeProxy.sol
+++ b/contracts/proxies/GnosisSafeProxy.sol
@@ -24,7 +24,7 @@ contract GnosisSafeProxy {
     }
 
     /// @dev Fallback function forwards all transactions and returns all received return data.
-    receive ()
+    fallback ()
         external
         payable
     {


### PR DESCRIPTION
Took me a while to figure out why it kept reverting when creating a proxy. Receive functions prevents calls without ether from being redirected. A payable fallback function accepts transactions with and without ether.